### PR TITLE
fix handling when the configs around the LinuxDeviceCgroup is not present.

### DIFF
--- a/oci_spec/src/lib.rs
+++ b/oci_spec/src/lib.rs
@@ -180,7 +180,6 @@ impl Spec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile;
 
     #[test]
     fn test_canonicalize_rootfs() -> Result<()> {

--- a/oci_spec/src/linux.rs
+++ b/oci_spec/src/linux.rs
@@ -541,28 +541,28 @@ pub struct LinuxNamespace {
 
 // Utility function to get default namespaces
 pub fn get_default_namespaces() -> Vec<LinuxNamespace> {
-    let mut default_namespace = Vec::new();
-    default_namespace.push(LinuxNamespace {
-        typ: LinuxNamespaceType::Pid,
-        path: Default::default(),
-    });
-    default_namespace.push(LinuxNamespace {
-        typ: LinuxNamespaceType::Network,
-        path: Default::default(),
-    });
-    default_namespace.push(LinuxNamespace {
-        typ: LinuxNamespaceType::Ipc,
-        path: Default::default(),
-    });
-    default_namespace.push(LinuxNamespace {
-        typ: LinuxNamespaceType::Uts,
-        path: Default::default(),
-    });
-    default_namespace.push(LinuxNamespace {
-        typ: LinuxNamespaceType::Mount,
-        path: Default::default(),
-    });
-    default_namespace
+    vec![
+        LinuxNamespace {
+            typ: LinuxNamespaceType::Pid,
+            path: Default::default(),
+        },
+        LinuxNamespace {
+            typ: LinuxNamespaceType::Network,
+            path: Default::default(),
+        },
+        LinuxNamespace {
+            typ: LinuxNamespaceType::Ipc,
+            path: Default::default(),
+        },
+        LinuxNamespace {
+            typ: LinuxNamespaceType::Uts,
+            path: Default::default(),
+        },
+        LinuxNamespace {
+            typ: LinuxNamespaceType::Mount,
+            path: Default::default(),
+        },
+    ]
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/oci_spec/src/linux.rs
+++ b/oci_spec/src/linux.rs
@@ -212,16 +212,13 @@ impl ToString for LinuxDeviceCgroup {
             .minor
             .map(|mi| mi.to_string())
             .unwrap_or_else(|| "*".to_string());
-        let unknown = "unknown".to_string();
+        let access = self.access.as_deref().unwrap_or("");
         format!(
             "{} {}:{} {}",
-            &self
-                .typ
-                .map(|x| x.as_str().to_string())
-                .unwrap_or(unknown.clone()),
+            &self.typ.unwrap_or_default().as_str(),
             &major,
             &minor,
-            &self.access.as_ref().unwrap_or(&unknown)
+            &access
         )
     }
 }

--- a/oci_spec/src/process.rs
+++ b/oci_spec/src/process.rs
@@ -243,7 +243,7 @@ impl Default for LinuxCapabilities {
             effective: default_vec.clone().into(),
             inheritable: default_vec.clone().into(),
             permitted: default_vec.clone().into(),
-            ambient: default_vec.clone().into(),
+            ambient: default_vec.into(),
         }
     }
 }

--- a/oci_spec/src/test.rs
+++ b/oci_spec/src/test.rs
@@ -13,18 +13,18 @@ fn serialize_and_deserialize_spec() {
 fn test_linux_device_cgroup_to_string() {
     let ldc = LinuxDeviceCgroup {
         allow: true,
-        typ: LinuxDeviceType::A,
+        typ: Some(LinuxDeviceType::A),
         major: None,
         minor: None,
-        access: "rwm".into(),
+        access: Some("rwm".into()),
     };
     assert_eq!(ldc.to_string(), "a *:* rwm");
     let ldc = LinuxDeviceCgroup {
         allow: true,
-        typ: LinuxDeviceType::A,
+        typ: Some(LinuxDeviceType::A),
         major: Some(1),
         minor: Some(9),
-        access: "rwm".into(),
+        access: Some("rwm".into()),
     };
     assert_eq!(ldc.to_string(), "a 1:9 rwm");
 }


### PR DESCRIPTION
- https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#allowed-device-list
> Unset values mean "all", mapping to a.
- https://github.com/opencontainers/runtime-spec/blob/82ab996a5bf91804a440391bff43140b17bbadd4/specs-go/config.go#L411
> omiteempty

I checked the CI in this PR.
https://github.com/utam0k/youki/pull/2